### PR TITLE
Get and replace fixes

### DIFF
--- a/inmem.go
+++ b/inmem.go
@@ -201,10 +201,6 @@ func (b *InMemBucket) GetAndReplace(ctx context.Context, name string, f func(io.
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
 
-	if reader == nil {
-		reader = io.NopCloser(bytes.NewReader(nil))
-	}
-
 	new, err := f(reader)
 	if err != nil {
 		return err

--- a/objstore.go
+++ b/objstore.go
@@ -66,6 +66,7 @@ type Bucket interface {
 
 	// GetAndReplace an existing object with a new object
 	// If the previous object is created or updated before the new object is uploaded, then the call will fail with an error.
+	// The existing reader will be nil in the case it did not previously exist.
 	GetAndReplace(ctx context.Context, name string, f func(existing io.Reader) (io.Reader, error)) error
 
 	// Delete removes the object with the given name.


### PR DESCRIPTION
* passes nil readers to callbacks when an object doesn't exist
* prevents issues where nil pointers with known concrete types won't pass nil-checks by the caller which sees an interface