### PR TITLE
chore: support io.ReadClosers for GetAndReplace

### DIFF
--- a/inmem.go
+++ b/inmem.go
@@ -193,7 +193,7 @@ func (b *InMemBucket) GetRange(_ context.Context, name string, off, length int64
 	}, nil
 }
 
-func (b *InMemBucket) GetAndReplace(ctx context.Context, name string, f func(io.Reader) (io.Reader, error)) error {
+func (b *InMemBucket) GetAndReplace(ctx context.Context, name string, f func(io.ReadCloser) (io.ReadCloser, error)) error {
 	reader, err := b.Get(ctx, name)
 	if err != nil && !errors.Is(err, errNotFound) {
 		return err
@@ -204,6 +204,8 @@ func (b *InMemBucket) GetAndReplace(ctx context.Context, name string, f func(io.
 	new, err := f(reader)
 	if err != nil {
 		return err
+	} else if new != nil {
+		defer new.Close()
 	}
 
 	newObj, err := io.ReadAll(new)

--- a/objstore.go
+++ b/objstore.go
@@ -67,7 +67,8 @@ type Bucket interface {
 	// GetAndReplace an existing object with a new object
 	// If the previous object is created or updated before the new object is uploaded, then the call will fail with an error.
 	// The existing reader will be nil in the case it did not previously exist.
-	GetAndReplace(ctx context.Context, name string, f func(existing io.Reader) (io.Reader, error)) error
+	// The callback function is responsible for closing the existing reader if it is non-nil.
+	GetAndReplace(ctx context.Context, name string, f func(existing io.ReadCloser) (io.ReadCloser, error)) error
 
 	// Delete removes the object with the given name.
 	// If object does not exist in the moment of deletion, Delete should throw error.
@@ -736,7 +737,7 @@ func (b *metricBucket) GetRange(ctx context.Context, name string, off, length in
 	), nil
 }
 
-func (b *metricBucket) GetAndReplace(ctx context.Context, name string, f func(io.Reader) (io.Reader, error)) error {
+func (b *metricBucket) GetAndReplace(ctx context.Context, name string, f func(io.ReadCloser) (io.ReadCloser, error)) error {
 	return b.bkt.GetAndReplace(ctx, name, f)
 }
 

--- a/prefixed_bucket.go
+++ b/prefixed_bucket.go
@@ -79,7 +79,7 @@ func (p *PrefixedBucket) GetRange(ctx context.Context, name string, off int64, l
 	return p.bkt.GetRange(ctx, conditionalPrefix(p.prefix, name), off, length)
 }
 
-func (b *PrefixedBucket) GetAndReplace(ctx context.Context, name string, f func(io.Reader) (io.Reader, error)) error {
+func (b *PrefixedBucket) GetAndReplace(ctx context.Context, name string, f func(io.ReadCloser) (io.ReadCloser, error)) error {
 	return b.bkt.GetAndReplace(ctx, conditionalPrefix(b.prefix, name), f)
 }
 

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -430,6 +430,6 @@ func (b *Bucket) Close() error {
 	return nil
 }
 
-func (b *Bucket) GetAndReplace(ctx context.Context, name string, f func(io.Reader) (io.Reader, error)) error {
+func (b *Bucket) GetAndReplace(ctx context.Context, name string, f func(io.ReadCloser) (io.ReadCloser, error)) error {
 	panic("unimplemented: Azure.GetAndReplace")
 }

--- a/providers/bos/bos.go
+++ b/providers/bos/bos.go
@@ -441,6 +441,6 @@ func validateForTest(conf Config) error {
 	return nil
 }
 
-func (b *Bucket) GetAndReplace(ctx context.Context, name string, f func(io.Reader) (io.Reader, error)) error {
+func (b *Bucket) GetAndReplace(ctx context.Context, name string, f func(io.ReadCloser) (io.ReadCloser, error)) error {
 	panic("unimplemented: BOS.GetAndReplace")
 }

--- a/providers/cos/cos.go
+++ b/providers/cos/cos.go
@@ -581,6 +581,6 @@ func createTemporaryTestBucketName(t testing.TB) string {
 	return strings.TrimSuffix(name, "-")
 }
 
-func (b *Bucket) GetAndReplace(ctx context.Context, name string, f func(io.Reader) (io.Reader, error)) error {
+func (b *Bucket) GetAndReplace(ctx context.Context, name string, f func(io.ReadCloser) (io.ReadCloser, error)) error {
 	panic("unimplemented: COS.GetAndReplace")
 }

--- a/providers/obs/obs.go
+++ b/providers/obs/obs.go
@@ -446,6 +446,6 @@ func configFromEnv() Config {
 	return c
 }
 
-func (b *Bucket) GetAndReplace(ctx context.Context, name string, f func(io.Reader) (io.Reader, error)) error {
+func (b *Bucket) GetAndReplace(ctx context.Context, name string, f func(io.ReadCloser) (io.ReadCloser, error)) error {
 	panic("unimplemented: OBS.GetAndReplace")
 }

--- a/providers/oci/oci.go
+++ b/providers/oci/oci.go
@@ -432,6 +432,6 @@ func NewTestBucket(t testing.TB) (objstore.Bucket, func(), error) {
 	}, nil
 }
 
-func (b *Bucket) GetAndReplace(ctx context.Context, name string, f func(io.Reader) (io.Reader, error)) error {
+func (b *Bucket) GetAndReplace(ctx context.Context, name string, f func(io.ReadCloser) (io.ReadCloser, error)) error {
 	panic("unimplemented: OCI.GetAndReplace")
 }

--- a/providers/oss/oss.go
+++ b/providers/oss/oss.go
@@ -427,6 +427,6 @@ func (b *Bucket) IsAccessDeniedErr(err error) bool {
 	return false
 }
 
-func (b *Bucket) GetAndReplace(ctx context.Context, name string, f func(io.Reader) (io.Reader, error)) error {
+func (b *Bucket) GetAndReplace(ctx context.Context, name string, f func(io.ReadCloser) (io.ReadCloser, error)) error {
 	panic("unimplemented: OSS.GetAndReplace")
 }

--- a/providers/swift/swift.go
+++ b/providers/swift/swift.go
@@ -375,7 +375,7 @@ func (c *Container) Upload(_ context.Context, name string, r io.Reader) (err err
 	return nil
 }
 
-func (b *Container) GetAndReplace(ctx context.Context, name string, f func(io.Reader) (io.Reader, error)) error {
+func (b *Container) GetAndReplace(ctx context.Context, name string, f func(io.ReadCloser) (io.ReadCloser, error)) error {
 	panic("unimplemented: Swift.GetAndReplace")
 }
 

--- a/testing.go
+++ b/testing.go
@@ -287,7 +287,7 @@ func (d *delayingBucket) Get(ctx context.Context, name string) (io.ReadCloser, e
 	return d.bkt.Get(ctx, name)
 }
 
-func (b *delayingBucket) GetAndReplace(ctx context.Context, name string, f func(io.Reader) (io.Reader, error)) error {
+func (b *delayingBucket) GetAndReplace(ctx context.Context, name string, f func(io.ReadCloser) (io.ReadCloser, error)) error {
 	panic("unimplemented: delayingBucket.GetAndReplace")
 }
 

--- a/tracing/opentelemetry/opentelemetry.go
+++ b/tracing/opentelemetry/opentelemetry.go
@@ -123,7 +123,7 @@ func (t TracingBucket) Upload(ctx context.Context, name string, r io.Reader) (er
 	return t.bkt.Upload(ctx, name, r)
 }
 
-func (t TracingBucket) GetAndReplace(ctx context.Context, name string, f func(io.Reader) (io.Reader, error)) (err error) {
+func (t TracingBucket) GetAndReplace(ctx context.Context, name string, f func(io.ReadCloser) (io.ReadCloser, error)) (err error) {
 	ctx, span := t.tracer.Start(ctx, "bucket_get_and_replace")
 	defer span.End()
 	span.SetAttributes(attribute.String("name", name))

--- a/tracing/opentracing/opentracing.go
+++ b/tracing/opentracing/opentracing.go
@@ -118,7 +118,7 @@ func (t TracingBucket) Upload(ctx context.Context, name string, r io.Reader) (er
 	return
 }
 
-func (t TracingBucket) GetAndReplace(ctx context.Context, name string, f func(io.Reader) (io.Reader, error)) (err error) {
+func (t TracingBucket) GetAndReplace(ctx context.Context, name string, f func(io.ReadCloser) (io.ReadCloser, error)) (err error) {
 	doWithSpan(ctx, "bucket_get_and_replace", func(spanCtx context.Context, span opentracing.Span) {
 		span.LogKV("name", name)
 		err = t.bkt.GetAndReplace(spanCtx, name, f)


### PR DESCRIPTION
This also changes the usage semantics so that the callback function is responsible for closing the existing reader (if non-nil).