### PR TITLE
fix(filesystem): Create subdirectories recursively in GetAndReplace operation

### DIFF
--- a/providers/filesystem/filesystem.go
+++ b/providers/filesystem/filesystem.go
@@ -272,6 +272,9 @@ func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) (err erro
 
 func (b *Bucket) GetAndReplace(ctx context.Context, name string, f func(io.ReadCloser) (io.ReadCloser, error)) error {
 	file := filepath.Join(b.rootDir, name)
+	if err := os.MkdirAll(filepath.Dir(file), os.ModePerm); err != nil {
+		return err
+	}
 
 	// Acquire a file lock before modifiying as file-systems don't support conditional writes like cloud providers.
 	fileLock := flock.New(file + ".lock")

--- a/providers/filesystem/filesystem_test.go
+++ b/providers/filesystem/filesystem_test.go
@@ -6,6 +6,7 @@ package filesystem
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"strings"
 	"sync"
@@ -153,6 +154,22 @@ func TestGetRange_CancelledContext(t *testing.T) {
 	_, err = b.GetRange(ctx, "some-file", 0, 100)
 	testutil.NotOk(t, err)
 	testutil.Equals(t, context.Canceled, err)
+}
+
+func TestGetAndReplace_Subdirectories(t *testing.T) {
+	b, err := NewBucket(t.TempDir())
+	testutil.Ok(t, err)
+
+	ctx := context.Background()
+	err = b.GetAndReplace(ctx, "foo/bar/baz.txt", func(rc io.ReadCloser) (io.ReadCloser, error) {
+		testutil.Assert(t, rc == nil, "file did not exist yet")
+		return io.NopCloser(strings.NewReader("baz old")), nil
+	})
+
+	err = b.GetAndReplace(ctx, "foo/bar/baz.txt", func(rc io.ReadCloser) (io.ReadCloser, error) {
+		testutil.Assert(t, rc != nil, "file existed")
+		return io.NopCloser(strings.NewReader("baz new")), nil
+	})
 }
 
 func TestExists_CancelledContext(t *testing.T) {


### PR DESCRIPTION
This PR fixes an issue that causes GetAndReplace operations in the filesystem provider to fail if the specified file is located in a subdirectory that does not exist yet.

Fixes https://github.com/grafana/loki/issues/21783