### PR TITLE
fix(filesystem): Respect canceled context in GetAndReplace operation

### DIFF
--- a/providers/filesystem/filesystem.go
+++ b/providers/filesystem/filesystem.go
@@ -271,6 +271,10 @@ func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) (err erro
 }
 
 func (b *Bucket) GetAndReplace(ctx context.Context, name string, f func(io.ReadCloser) (io.ReadCloser, error)) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	file := filepath.Join(b.rootDir, name)
 	if err := os.MkdirAll(filepath.Dir(file), os.ModePerm); err != nil {
 		return err

--- a/providers/filesystem/filesystem_test.go
+++ b/providers/filesystem/filesystem_test.go
@@ -172,6 +172,26 @@ func TestGetAndReplace_Subdirectories(t *testing.T) {
 	})
 }
 
+func TestGetAndReplace_CancelledContext(t *testing.T) {
+	b, err := NewBucket(t.TempDir())
+	testutil.Ok(t, err)
+
+	// create file
+	err = b.Upload(context.Background(), "foo.txt", strings.NewReader("foo"))
+	testutil.Ok(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// try to replace file, replace file
+	err = b.GetAndReplace(ctx, "foo.txt", func(_ io.ReadCloser) (io.ReadCloser, error) {
+		testutil.Assert(t, false) // must never get there because of cancelled context
+		return io.NopCloser(strings.NewReader("bar")), nil
+	})
+	testutil.NotOk(t, err)
+	testutil.Equals(t, context.Canceled, err)
+}
+
 func TestExists_CancelledContext(t *testing.T) {
 	b, err := NewBucket(t.TempDir())
 	testutil.Ok(t, err)


### PR DESCRIPTION
This PR ensures that GetAndReplace operations return early in case the context is already canceled.